### PR TITLE
Update registration cut-off dates

### DIFF
--- a/model/dates.php
+++ b/model/dates.php
@@ -17,7 +17,7 @@ $dates = array(
   'indiv_shame_end' => mktime(23,59,59,11,8,2014),
   'full_player_refund' => mktime(23,59,59,10,15,2014),
   //'partial_player_refund' => mktime(23,59,59,11,2,2013),
-  'online_payment' => mktime(23,59,59,11,3,2014),
+  'online_payment' => mktime(23,59,59,11,1,2014),
   //'guest_list' => mktime(23,59,59,11,6,2013),
 );
 // Derived dates:


### PR DESCRIPTION
Change late registration cutoff date to 10/24, online payment cutoff to 11/1, ALL YEARS TO 2014.  Should the indiv_shame_end be changed?  Maybe it should be changed back to 11/1?  I'm not quite sure how it's used, but I guess the online payment cutoff is the key?
